### PR TITLE
Parameters may be truncated when setting the number of repetitions of the animation

### DIFF
--- a/src/drivers/sdl/lv_sdl_window.c
+++ b/src/drivers/sdl/lv_sdl_window.c
@@ -399,8 +399,8 @@ static void texture_resize(lv_display_t * disp)
     }
     else {
 #if LV_SDL_BUF_COUNT == 2
-        dsc->fb2 = realloc(dsc->fb2, stride * ver_res);
-        memset(dsc->fb2, 0x00, stride * ver_res);
+        dsc->fb2 = realloc(dsc->fb2, stride * disp->ver_res);
+        memset(dsc->fb2, 0x00, stride * disp->ver_res);
 #endif
         lv_display_set_buffers(disp, dsc->fb1, dsc->fb2, stride * disp->ver_res, LV_SDL_RENDER_MODE);
     }


### PR DESCRIPTION
The parameter passing is truncated, resulting in inconsistent parameters between the configured parameters and the read parameters

